### PR TITLE
Add silent getAccounts call support

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -11,6 +11,7 @@
 # misc
 .DS_Store
 .eslintcache
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-metamask",
-  "version": "1.1.2",
+  "version": "1.2.2",
   "description": "Connect Metamask with React Hook",
   "author": {
     "name": "Muhammed Tanrikulu",

--- a/src/useMetamask.js
+++ b/src/useMetamask.js
@@ -29,11 +29,11 @@ const useMetamask = () => {
   }, []);
   
   const connect = async (Web3Interface, settings = {}) => {
-    if (!provider)                throw Error("Metamask is not available");
+    if (!provider)                throw Error("Metamask is not available.");
     if (!Web3Interface) 
-      throw Error("Web3 Provider is required. You can use either ethers.js or web3.js");
-    if (!_isMounted.current)      throw Error("Component is not mounted");
-    if (_isConnectCalled.current) throw Error("Connect method already called");
+      throw Error("Web3 Provider is required. You can use either ethers.js or web3.js.");
+    if (!_isMounted.current)      throw Error("Component is not mounted.");
+    if (_isConnectCalled.current) throw Error("Connect method already called.");
     _isConnectCalled.current = true;
     
     const _web3 = new Web3Interface(
@@ -43,7 +43,7 @@ const useMetamask = () => {
     );
     dispatch({ type: "SET_WEB3", payload: _web3 });
     
-    await getAccounts();
+    await getAccounts({ requestPermission: true });
     await getChain();
     
     window.ethereum.on("accountsChanged", (accounts) => {
@@ -60,10 +60,14 @@ const useMetamask = () => {
     _isConnectCalled.current = false;
   };
 
-  const getAccounts = async () => {
+  const getAccounts = async ({ requestPermission } = { requestPermission: false }) => {
+    if (!provider) {
+      console.warn("Metamask is not available.");
+      return;
+    }
     try {
       const accounts = await provider.request({
-        method: "eth_requestAccounts",
+        method: requestPermission ? "eth_requestAccounts" : "eth_accounts",
         params: []
       });
       if (accounts.length) {
@@ -77,6 +81,10 @@ const useMetamask = () => {
   }
 
   const getChain = async () => {
+    if (!provider) {
+      console.warn("Metamask is not available.");
+      return;
+    }
     try {
       const chainId = await provider.request({
         method: "net_version",

--- a/test/useMetamask.test.js
+++ b/test/useMetamask.test.js
@@ -19,6 +19,12 @@ describe("When Metamask Available", () => {
         if (accounts instanceof Error) throw accounts;
         return accounts;
       }
+      console.log("method", method);
+      if (method === "eth_accounts") {
+        if (accounts instanceof Error) throw accounts;
+        accounts = ["0xSomethingWithoutPermission"]
+        return accounts;
+      }
     })
   }
   const modifyListener = (chainId = 1, accounts = ["0xSomething"]) => {
@@ -180,7 +186,7 @@ describe("When Metamask Available", () => {
         await result.current.connect();
       } catch (error) {
         expect(error.message).toEqual(
-          "Web3 Provider is required. You can use either ethers.js or web3.js"
+          "Web3 Provider is required. You can use either ethers.js or web3.js."
         );
       }
     });
@@ -234,7 +240,7 @@ describe("When Metamask Available", () => {
         result.current.connect(Web3Interface);
         await result.current.connect(Web3Interface);
       } catch (error) {
-        expect(error.message).toEqual("Connect method already called");
+        expect(error.message).toEqual("Connect method already called.");
       }
     });
   });
@@ -248,8 +254,25 @@ describe("When Metamask Available", () => {
       try {
         await result.current.connect(Web3Interface);
       } catch (error) {
-        expect(error.message).toEqual("Component is not mounted");
+        expect(error.message).toEqual("Component is not mounted.");
       }
+    });
+  });
+
+  test("getAccounts should call the account without Metamask permission", async () => {
+    const { result } = renderHook(() => useMetamask(), { wrapper });
+    await act(async () => {
+      await result.current.getAccounts();
+      expect(result.current.metaState.isConnected).toBe(true);
+      expect(result.current.metaState.account).toEqual(["0xSomethingWithoutPermission"]);
+    });
+  });
+
+  test("getChain should return current chain information", async () => {
+    const { result } = renderHook(() => useMetamask(), { wrapper });
+    await act(async () => {
+      await result.current.getChain();
+      expect(result.current.metaState.chain).toEqual({id: "1", name: "mainnet"});
     });
   });
 });
@@ -276,8 +299,24 @@ describe("When Metamask is not Available", () => {
       try {
         await result.current.connect(Web3Interface);
       } catch (error) {
-        expect(error.message).toEqual("Metamask is not available");
+        expect(error.message).toEqual("Metamask is not available.");
       }
+    });
+  });
+
+  test("getAccounts should return with a warning", async () => {
+    const { result } = renderHook(() => useMetamask(), { wrapper });
+    await act(async () => {
+      await result.current.getAccounts();
+      expect(result.current.metaState.account).toEqual([]);
+    });
+  });
+
+  test("getChain should return empty chain information", async () => {
+    const { result } = renderHook(() => useMetamask(), { wrapper });
+    await act(async () => {
+      await result.current.getChain();
+      expect(result.current.metaState.chain).toEqual({id: null, name: ""});
     });
   });
 });


### PR DESCRIPTION
Resolves #8.

`getAccounts()` method now have a new optional named parameter which is called `requestPermission` and by default it is `false`. 

Thus `getAccounts()` will make a `eth_accounts` call to the metamask when `requestPermission` is `false` which won't popup metamask window, will only check if there is any account connected to the dapp. 

On the other hand, `getAccounts({requestPermission: true})` will make a `eth_requestAccounts` call which will check if the metamask account connected to the dapp. If not then metamask will popup for user permission.